### PR TITLE
bind event handler to emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ Ever.prototype.on = function (name, cb, useCapture) {
     if (!this._events) this._events = {};
     if (!this._events[name]) this._events[name] = [];
     this._events[name].push(cb);
-    this.element.addEventListener(name, cb, useCapture || false);
+    this.element.addEventListener(name, cb.bind(this), useCapture || false);
 
     return this;
 };


### PR DESCRIPTION
`EventEmitter.prototype.once` expects `this` to be the emitter so it can `removeListener`
